### PR TITLE
Put aimeos in own main module 

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -20,8 +20,21 @@ $TBE_MODULES_EXT['xMOD_db_new_content_el']['addElClasses']['Aimeos\\Aimeos\\Cust
 if ( TYPO3_MODE === 'BE' )
 {
 	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
+	        'Aimeos.' . $_EXTKEY,
+	        'Aimeos',
+	        '',
+	        '',
+	        [],
+	        [
+	            'icon' => 'EXT:' . $_EXTKEY . '/Resources/Public/Icons/Extension.svg',
+	            'access' => 'user,group',
+	            'labels' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/admin.xlf',
+	        ]
+    	);
+
+	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
 		'Aimeos.' . $_EXTKEY,
-		'web',
+		'Aimeos',
 		'tx_aimeos_admin',
 		'', // position
 		array(


### PR DESCRIPTION
All modules under "web" will show the directory panel in Typo3.
As this just uses up space and has no meaning to aimeos, there are 2 options:
1)  Put the aimeos module in the existing main modules 'system', 'user' or 'tools'
2) Insert new "Aimeos" main module

- I went for the second option as neither of the existing categories really fits and I wanted Aimeos to "stand out" from the other modules. From Typo3 v7+ on the main module will also show an icon which adds clarity for the editor.